### PR TITLE
I've addressed an `OSError` that was occurring when saving thumbnails…

### DIFF
--- a/app.py
+++ b/app.py
@@ -86,7 +86,8 @@ def thumbnail(image_id):
         try:
             with Image.open(image_record['filepath']) as img:
                 img.thumbnail(THUMBNAIL_SIZE)
-                img.save(thumbnail_path, 'JPEG')
+                # Convert to RGB before saving as JPEG to handle RGBA images (e.g. PNGs)
+                img.convert('RGB').save(thumbnail_path, 'JPEG')
         except FileNotFoundError:
             # If the original image is missing, create a placeholder
             img = Image.new('RGB', THUMBNAIL_SIZE, color = 'gray')


### PR DESCRIPTION
… for RGBA images. This happened when the application tried to create a thumbnail from an image with an alpha (transparency) channel, such as a PNG file. I've corrected this by converting the image to 'RGB' mode before saving it as a JPEG, which removes the transparency layer and makes it compatible with the JPEG format.