### PR TITLE
I implemented new gallery navigation and a dedicated search page.

### DIFF
--- a/database.py
+++ b/database.py
@@ -69,6 +69,23 @@ def search_images_by_tag(query):
     conn.close()
     return images
 
+def get_available_years():
+    """Returns a sorted list of distinct years from the database."""
+    conn = get_db_connection()
+    # SUBSTR(date_taken, 1, 4) extracts the year from 'YYYY-MM-DD...'
+    years = conn.execute("SELECT DISTINCT SUBSTR(date_taken, 1, 4) as year FROM images ORDER BY year DESC").fetchall()
+    conn.close()
+    return [row['year'] for row in years]
+
+def get_images_by_year(year):
+    """Fetches all images from the database for a specific year."""
+    conn = get_db_connection()
+    # Using LIKE to match the start of the date_taken string
+    year_pattern = f"{year}%"
+    images = conn.execute("SELECT * FROM images WHERE date_taken LIKE ? ORDER BY date_taken ASC", (year_pattern,)).fetchall()
+    conn.close()
+    return images
+
 def insert_image(image_data):
     """Inserts a new image record into the database."""
     conn = get_db_connection()

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,40 +4,49 @@
 
 {% block content %}
 <div class="d-flex justify-content-between align-items-center mb-4">
-    <h1>My Photo Gallery</h1>
-</div>
-
-<form method="get" action="{{ url_for('index') }}" class="mb-4">
-    <div class="input-group">
-        <input type="search" name="query" class="form-control" placeholder="Search by tag (e.g., cat, outdoor)..." value="{{ request.args.get('query', '') }}">
-        <div class="input-group-append">
-            <button type="submit" class="btn btn-primary">Search</button>
-            {% if request.args.get('query') %}
-                <a href="{{ url_for('index') }}" class="btn btn-secondary">Clear</a>
-            {% endif %}
-        </div>
+    <h1>Photo Gallery</h1>
+    <div class="d-flex align-items-center">
+        <a href="{{ url_for('search') }}" class="btn btn-outline-primary mr-3">Search</a>
+        <form method="get" action="{{ url_for('index') }}" class="form-inline">
+            <label for="year-select" class="mr-2">Year:</label>
+            <select name="year" id="year-select" class="form-control" onchange="this.form.submit()">
+                {% for year in available_years %}
+                    <option value="{{ year }}" {% if year == selected_year %}selected{% endif %}>{{ year }}</option>
+                {% endfor %}
+            </select>
+        </form>
     </div>
-</form>
+</div>
 
 {% if not images %}
     <div class="alert alert-info">
-        No images found. The application might still be scanning or the directory is empty.
+        No images found for the selected year.
     </div>
 {% else %}
-    <div class="gallery">
-        {% for image in images %}
-        <div class="thumbnail">
-            <div class="card">
-                <a href="{{ url_for('image_viewer', image_id=image.id) }}">
-                    <img src="{{ url_for('thumbnail', image_id=image.id) }}" class="card-img-top" alt="{{ image.filename }}">
-                </a>
-                <div class="card-body">
-                    <p class="card-text text-truncate" title="{{ image.filename }}">{{ image.filename }}</p>
-                    <p class="card-text"><small class="text-muted">Taken: {{ image.date_taken.split('T')[0] }}</small></p>
+    {% for month, items in images | groupby('date_taken[5:7]') %}
+        <h2 class="mt-5">{{ items[0].date_taken | strptime('%Y-%m-%dT%H:%M:%S') | strftime('%B') }}</h2>
+        <hr>
+        <div class="gallery">
+            {% for image in items %}
+            <div class="thumbnail">
+                <div class="card">
+                    <a href="{{ url_for('image_viewer', image_id=image.id) }}">
+                        <img src="{{ url_for('thumbnail', image_id=image.id) }}" class="card-img-top" alt="{{ image.filename }}">
+                    </a>
+                    <div class="card-body">
+                        <p class="card-text text-truncate" title="{{ image.filename }}">{{ image.filename }}</p>
+                        <p class="card-text"><small class="text-muted">Taken: {{ image.date_taken.split('T')[0] }}</small></p>
+                    </div>
                 </div>
             </div>
+            {% endfor %}
         </div>
-        {% endfor %}
-    </div>
+    {% endfor %}
 {% endif %}
+{% endblock %}
+
+{% block extra_head %}
+<style>
+    /* Add any additional styles if needed */
+</style>
 {% endblock %}

--- a/templates/search.html
+++ b/templates/search.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% block title %}Search Photos{% endblock %}
+
+{% block content %}
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1>Search Photos</h1>
+    <a href="{{ url_for('index') }}">&larr; Back to Gallery</a>
+</div>
+
+<form method="get" action="{{ url_for('search') }}" class="mb-4">
+    <div class="input-group">
+        <input type="search" name="query" class="form-control" placeholder="Search by tag (e.g., cat, outdoor)..." value="{{ request.args.get('query', '') }}" autofocus>
+        <div class="input-group-append">
+            <button type="submit" class="btn btn-primary">Search</button>
+        </div>
+    </div>
+</form>
+
+{% if images is defined %}
+    {% if not images %}
+        <div class="alert alert-warning">
+            No images found matching your query: <strong>{{ request.args.get('query') }}</strong>
+        </div>
+    {% else %}
+        <p class="text-muted">Found {{ images|length }} image(s) matching your query.</p>
+        <div class="gallery">
+            {% for image in images %}
+            <div class="thumbnail">
+                <div class="card">
+                    <a href="{{ url_for('image_viewer', image_id=image.id) }}">
+                        <img src="{{ url_for('thumbnail', image_id=image.id) }}" class="card-img-top" alt="{{ image.filename }}">
+                    </a>
+                    <div class="card-body">
+                        <p class="card-text text-truncate" title="{{ image.filename }}">{{ image.filename }}</p>
+                        <p class="card-text"><small class="text-muted">Tags: {{ image.llm_tags }}</small></p>
+                    </div>
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+    {% endif %}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
This commit refactors the main photo gallery page and search functionality based on your feedback.

Key changes:
- The main gallery page now allows you to select a year from a dropdown menu.
- Images for the selected year are displayed, grouped by month with clear headers.
- The search bar has been removed from the main gallery.
- A new, dedicated `/search` page has been created to house the search functionality.
- A custom `strptime` Jinja2 filter was added to `app.py` to facilitate date formatting in the templates.