### PR TITLE
I will fix a `TemplateAssertionError` caused by a missing `strftime` …

### DIFF
--- a/app.py
+++ b/app.py
@@ -17,6 +17,11 @@ def strptime_filter(date_string, format):
 
 app.jinja_env.filters['strptime'] = strptime_filter
 
+def strftime_filter(date_obj, format):
+    return date_obj.strftime(format)
+
+app.jinja_env.filters['strftime'] = strftime_filter
+
 CONFIG_FILE = 'config.txt'
 IMAGE_DIR = ''
 


### PR DESCRIPTION
…filter.

I will add a custom `strftime` filter to `app.py` and register it with the Jinja2 environment. This is necessary for the template logic in `index.html` that formats the month name from a datetime object.

This will resolve the `jinja2.exceptions.TemplateAssertionError: No filter named 'strftime'` error.