### PR TITLE
I've fixed a Jinja2 error related to the `groupby` filter.

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,13 @@ def index():
 
     images = []
     if selected_year:
-        images = database.get_images_by_year(selected_year)
+        image_records = database.get_images_by_year(selected_year)
+        # Convert Row objects to dictionaries and add a month_name attribute for grouping
+        for record in image_records:
+            image_dict = dict(record)
+            dt_object = datetime.strptime(image_dict['date_taken'], '%Y-%m-%dT%H:%M:%S')
+            image_dict['month_name'] = dt_object.strftime('%B')
+            images.append(image_dict)
 
     return render_template('index.html', images=images, available_years=available_years, selected_year=selected_year)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,8 +23,8 @@
         No images found for the selected year.
     </div>
 {% else %}
-    {% for month, items in images | groupby('date_taken[5:7]') %}
-        <h2 class="mt-5">{{ items[0].date_taken | strptime('%Y-%m-%dT%H:%M:%S') | strftime('%B') }}</h2>
+    {% for month, items in images | groupby('month_name') %}
+        <h2 class="mt-5">{{ month }}</h2>
         <hr>
         <div class="gallery">
             {% for image in items %}


### PR DESCRIPTION
This addresses an error that occurred in the `groupby` filter in `index.html`. The previous method of grouping by a string slice was unreliable.

The new implementation is more robust:
- In `app.py`, the `index` route now processes the list of images after fetching them from the database.
- A `month_name` attribute (e.g., "January") is added to each image dictionary.
- The `index.html` template now uses the simple and reliable `groupby('month_name')` to group images.
- This removes the need for complex filtering in the template and resolves the underlying error.