### PR TITLE
I've fixed a `ValueError` that was happening when parsing date string…

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,7 +71,9 @@ def index():
         # Convert Row objects to dictionaries and add a month_name attribute for grouping
         for record in image_records:
             image_dict = dict(record)
-            dt_object = datetime.strptime(image_dict['date_taken'], '%Y-%m-%dT%H:%M:%S')
+            # Truncate fractional seconds before parsing
+            date_str = image_dict['date_taken'].split('.')[0]
+            dt_object = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S')
             image_dict['month_name'] = dt_object.strftime('%B')
             images.append(image_dict)
 


### PR DESCRIPTION
…s with fractional seconds.

This resolves a `ValueError: unconverted data remains` that occurred when processing `date_taken` strings from EXIF data that included fractional seconds.

The fix modifies the `index` route in `app.py` to truncate the date string at the decimal point before parsing it with `strptime`. This makes the date parsing more robust and prevents crashes when encountering more precise timestamps.