### PR TITLE
This commit addresses two bugs you reported.

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,8 +110,9 @@ def settings():
             if directory and os.path.isdir(directory) and directory not in IMAGE_DIRS:
                 IMAGE_DIRS.append(directory)
                 save_config()
-                flash(f"Added directory: {directory}. Scanning in the background.", 'success')
-                scan_thread = threading.Thread(target=scanner.scan_directories, args=([directory], scan_status), daemon=True)
+                flash(f"Added directory: {directory}. Scanning all directories for new files.", 'success')
+                # Always scan all directories to prevent deleting data from other folders
+                scan_thread = threading.Thread(target=scanner.scan_directories, args=(IMAGE_DIRS, scan_status), daemon=True)
                 scan_thread.start()
 
         elif action == 'remove_folder':

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -33,12 +33,8 @@
         <form method="post" action="{{ url_for('settings') }}">
             <input type="hidden" name="action" value="add_folder">
             <div class="form-group">
-                <label for="directory-input-settings">New Directory Path</label>
-                <input type="text" class="form-control" id="directory-input-settings" name="directory" placeholder="Select a folder or paste a path here..." required>
-            </div>
-            <div class="form-group">
-                <label for="folder-picker-settings" class="btn btn-info">Browse for Folder</label>
-                <input type="file" id="folder-picker-settings" webkitdirectory directory style="display: none;">
+                <label for="directory">New Directory Path</label>
+                <input type="text" class="form-control" id="directory" name="directory" placeholder="/path/to/your/photos" required>
             </div>
             <button type="submit" class="btn btn-primary">Add and Scan</button>
         </form>
@@ -70,15 +66,6 @@
 
 {% block scripts %}
 <script>
-document.getElementById('folder-picker-settings').addEventListener('change', function(event) {
-    if (event.target.files.length > 0) {
-        const firstFile = event.target.files[0];
-        const relativePath = firstFile.webkitRelativePath;
-        const directoryPath = firstFile.path.substring(0, firstFile.path.length - relativePath.length);
-        document.getElementById('directory-input-settings').value = directoryPath;
-    }
-});
-
 document.addEventListener('DOMContentLoaded', function() {
     const statusMessage = document.getElementById('scan-status-message');
     const progressBar = document.getElementById('scan-progress-bar');

--- a/templates/setup.html
+++ b/templates/setup.html
@@ -12,33 +12,14 @@
 
                 <form method="post">
                     <div class="form-group">
-    <label for="directory-input">Photo Directory Path</label>
-    <input type="text" class="form-control" id="directory-input" name="directory" placeholder="Select a folder or paste a path here..." required>
-    <small class="form-text text-muted">Use the button below to browse for a folder. This will scan the directory and all its subdirectories for images.</small>
-</div>
-<div class="form-group">
-    <label for="folder-picker" class="btn btn-info">Browse for Folder</label>
-    <input type="file" id="folder-picker" webkitdirectory directory style="display: none;">
-</div>
+                        <label for="directory">Photo Directory Path</label>
+                        <input type="text" class="form-control" id="directory" name="directory" placeholder="/Users/yourname/Pictures or C:\Users\yourname\Pictures" required>
+                        <small class="form-text text-muted">You can add more directories later from the Settings page.</small>
+                    </div>
                     <button type="submit" class="btn btn-primary">Save and Scan</button>
                 </form>
             </div>
         </div>
     </div>
 </div>
-{% endblock %}
-
-{% block scripts %}
-<script>
-document.getElementById('folder-picker').addEventListener('change', function(event) {
-    if (event.target.files.length > 0) {
-        // The path of the first file will contain the directory path.
-        // The `webkitRelativePath` includes the folder structure.
-        const firstFile = event.target.files[0];
-        const relativePath = firstFile.webkitRelativePath;
-        const directoryPath = firstFile.path.substring(0, firstFile.path.length - relativePath.length);
-        document.getElementById('directory-input').value = directoryPath;
-    }
-});
-</script>
 {% endblock %}


### PR DESCRIPTION
1.  **Fix Data Deletion on Add Folder:**
    - I've corrected the logic in the `add_folder` action in `app.py`.
    - Previously, scanning only the newly added directory caused the "smart scan" to incorrectly delete all images from other, existing directories.
    - The fix ensures that after adding a new folder, a scan is triggered on the complete list of all configured directories, which correctly adds new files without deleting existing ones.

2.  **Fix Confusing Folder Browser UX:**
    - I've removed the "Browse for Folder" button from `setup.html` and `settings.html`.
    - Due to browser security limitations, this feature could not reliably get the full folder path and created a confusing experience.
    - The UI has been reverted to a simple and clear text input for you to paste the directory path, which is a more robust and less confusing interaction.